### PR TITLE
Wrong parameters for NoResultsException

### DIFF
--- a/src/lastfmapi/Api/AlbumApi.php
+++ b/src/lastfmapi/Api/AlbumApi.php
@@ -256,7 +256,7 @@ class AlbumApi extends BaseApi
 
                     return $searchresults;
                 } else {
-                    throw new NoResultsException(90, 'No results');
+                    throw new NoResultsException('No results', 90);
                 }
             } else {
                 return false;


### PR DESCRIPTION
Fix arguments order for NoResultsException([string $message [, long $code [, Throwable $previous = NULL]]])